### PR TITLE
Update bigcommerce gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'sinatra'
 gem 'thin'
 gem 'rest-client'
 gem 'dotenv'
-gem 'bigcommerce', :github => 'mechatama/bigcommerce-api-ruby', :branch => 'oauth'
+gem 'bigcommerce'
 gem 'datamapper'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: git://github.com/mechatama/bigcommerce-api-ruby.git
-  revision: e1efeb63df5f4a5f5c2b054334ea27d21eeee000
-  branch: oauth
-  specs:
-    bigcommerce (0.9.1)
-      activesupport
-      json
-      rest-client
-
-GIT
   remote: https://github.com/bigcommerce/omniauth-bigcommerce.git
   revision: 82ee4772e2de5faecdd22c4e2f1ea3388954ea95
   specs:
@@ -19,16 +9,20 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.1.4)
-      i18n (~> 0.6, >= 0.6.9)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.6)
     bcrypt (3.1.7)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
+    bigcommerce (0.10.0)
+      activesupport
+      json
+      rest-client
     daemons (1.1.9)
     data_objects (0.10.14)
       addressable (~> 2.1)
@@ -91,12 +85,12 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     hashie (2.1.2)
-    i18n (0.6.11)
+    i18n (0.7.0)
     json (1.8.1)
     json_pure (1.8.1)
     jwt (1.0.0)
     mime-types (2.3)
-    minitest (5.4.0)
+    minitest (5.5.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -134,7 +128,7 @@ GEM
       rack (>= 1.0.0)
     thread_safe (0.3.4)
     tilt (1.4.1)
-    tzinfo (1.2.1)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uuidtools (2.1.4)
 
@@ -142,7 +136,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bigcommerce!
+  bigcommerce
   datamapper
   dm-postgres-adapter
   dm-sqlite-adapter


### PR DESCRIPTION
Update bigcommerce gem to use the most recent version uploaded to rubygems rather than pointing to the git repository.