### PR TITLE
should listen on 0.0.0.0

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup --port $PORT
+web: bundle exec rackup -o 0.0.0.0 --port $PORT


### PR DESCRIPTION
## Context: 

The Procfile is used by foreman as a process manager.
In this case, we use it to start rackup. By default rackup will listen on `localhost`. 
This commit will change that so that it'll listen on any interface, to make the server accessible from clients outside localhost.

cc @mattolson @pedelman @bc-croh92 