### PR TITLE
read scopes and context from omniauth response

### DIFF
--- a/hello.rb
+++ b/hello.rb
@@ -92,9 +92,9 @@ get '/auth/:name/callback' do
   end
 
   email = auth[:info][:email]
-  store_hash = auth[:extra][:raw_info][:context].split('/')[1]
+  store_hash = auth[:extra][:context].split('/')[1]
   token = auth[:credentials][:token].token
-  scope = params[:scope]
+  scope = auth[:extra][:scopes]
 
   # Lookup store
   store = Store.first(store_hash: store_hash)


### PR DESCRIPTION
## Before

- We were not sending the scopes in the oauth response payload.
- context was set in the extra, so no need to read it from raw_info

## After

- load the scopes from the oauth response payload
- read the context and scopes from `auth[:extra]`

cc @bigcommerce/ruby-sf 