### PR TITLE
Update usage of Bigcommerce ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby ENV['CUSTOM_RUBY_VERSION'] || '2.2.5'
 
-gem 'bigcommerce'
+gem 'bigcommerce', '~> 1.0'
 gem 'omniauth-bigcommerce', '~> 0.3.0'
 
 gem 'sinatra', '~> 1.4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     addressable (2.4.0)
     bcrypt (3.1.11)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
-    bigcommerce (0.10.0)
-      activesupport
-      json
-      rest-client
+    bigcommerce (1.0.0)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10.0)
+      hashie (~> 3.4)
     cachy (0.4.1)
       mini_memory_store
     daemons (1.2.3)
@@ -71,30 +65,25 @@ GEM
       data_objects (= 0.10.17)
     do_sqlite3 (0.10.17)
       data_objects (= 0.10.17)
-    domain_name (0.5.20160310)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     eventmachine (1.2.0.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     fastercsv (1.5.5)
     hashie (3.4.4)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     json_pure (1.8.3)
     jwt (1.5.1)
-    mime-types (2.99.1)
     mini_memory_store (0.1.0)
-    minitest (5.8.4)
     money (6.7.1)
       i18n (>= 0.6.4, <= 0.7.0)
       sixarm_ruby_unaccent (>= 1.1.1, < 2)
     multi_json (1.12.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    netrc (0.11.0)
     oauth2 (1.1.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0, < 1.5.2)
@@ -115,10 +104,6 @@ GEM
     rack-protection (1.5.3)
       rack
     redis (3.3.1)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -130,20 +115,14 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
-    thread_safe (0.3.5)
     tilt (2.0.2)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
     uuidtools (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bigcommerce
+  bigcommerce (~> 1.0)
   cachy
   datamapper
   dm-postgres-adapter
@@ -163,4 +142,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.6
+   1.16.4


### PR DESCRIPTION
#### What?
This sample application currently uses an old version of the Biggcommerce Ruby gem that is incompatible with the current release. This PR locks the gem version to greater than 1.0.0, and updates the usage in the app accordingly.


